### PR TITLE
fix: persist reordered quick links in Firefox

### DIFF
--- a/shared/quickLinks/quickLinksStore.ts
+++ b/shared/quickLinks/quickLinksStore.ts
@@ -60,6 +60,23 @@ function hasQuickLinksData(data: QuickLinksData): boolean {
   return data.items.length > 0 || (data.groups?.length ?? 0) > 0
 }
 
+function toStorageQuickLink(item: QuickLink): QuickLink {
+  const quickLink: QuickLink = {
+    url: item.url,
+    title: item.title,
+  }
+  if (item.favicon !== undefined) quickLink.favicon = item.favicon
+  return quickLink
+}
+
+function toStorageQuickLinkGroup(group: QuickLinkGroup): QuickLinkGroup {
+  return {
+    id: group.id,
+    name: group.name,
+    items: group.items.map(toStorageQuickLink),
+  }
+}
+
 export const useQuickLinksStore = defineStore('quickLinks', () => {
   const settings = useSettingsStore()
   const flatItems = ref(structuredClone(defaultQuickLinksData.items))
@@ -151,13 +168,13 @@ export const useQuickLinksStore = defineStore('quickLinks', () => {
 
   const getSnapshot = (groupingEnabled = settings.quickLinks.grouping): QuickLinksData => {
     if (groupingEnabled && groupState.value.length > 0) {
-      const snapshotGroups = structuredClone(toRaw(groupState.value))
+      const snapshotGroups = groupState.value.map(toStorageQuickLinkGroup)
       return {
         items: flattenQuickLinkGroups(snapshotGroups),
         groups: snapshotGroups,
       }
     }
-    return { items: structuredClone(toRaw(flatItems.value)), groups: [] }
+    return { items: flatItems.value.map(toStorageQuickLink), groups: [] }
   }
 
   const persistSnapshot = async (snapshot: QuickLinksData) => {


### PR DESCRIPTION
## Summary

- Serialize quick links and groups into plain objects before creating the storage snapshot.
- Prevent nested Vue reactive proxies from reaching Firefox structured cloning and `browser.storage.local`.

## Root cause

After drag sorting, nested quick-link objects can remain Vue reactive proxies. `getSnapshot()` only unwrapped the outer array, so Firefox could throw `DataCloneError: Proxy object could not be cloned`. The UI order changed, but the updated order was never persisted and reverted after reload.

## Verification

- `pnpm exec eslint shared/quickLinks/quickLinksStore.ts`
- `pnpm exec wxt zip -b firefox`
- Real Firefox automation: drag order persisted to storage, survived reload, and external storage updates still synchronized back to the UI.