### PR TITLE
✨ 增加右键背景打开启动台设置并与书签右键互斥

### DIFF
--- a/entrypoints/newtab/App.vue
+++ b/entrypoints/newtab/App.vue
@@ -132,8 +132,14 @@ watch(
   },
 )
 
-function openBookmarkSidebar() {
-  if (settings.bookmark.rightClickToOpen) {
+function handleBackgroundContextMenu() {
+  if (
+    settings.dock.enabled &&
+    settings.dock.launchpad.enabled &&
+    settings.dock.launchpad.rightClickToOpen
+  ) {
+    DockRef.value?.toggleLaunchpad()
+  } else if (settings.bookmark.rightClickToOpen) {
     void showBookmark()
   }
 }
@@ -256,7 +262,7 @@ function toggleMinimalMode() {
       class="app"
       :class="mainClass"
       :aria-label="t('a11y.main')"
-      @contextmenu.prevent="openBookmarkSidebar"
+      @contextmenu.prevent="handleBackgroundContextMenu"
       @dblclick.self="toggleMinimalMode"
     >
       <clock v-if="settings.clock.enabled" @contextmenu.stop />

--- a/entrypoints/newtab/components/QuickLinks/Dock.vue
+++ b/entrypoints/newtab/components/QuickLinks/Dock.vue
@@ -362,7 +362,7 @@ function toggleLaunchpad() {
   showLaunchpad.value = !showLaunchpad.value
 }
 
-defineExpose({ refresh })
+defineExpose({ refresh, toggleLaunchpad })
 </script>
 
 <template>

--- a/entrypoints/newtab/components/SettingsPage/Settings/BookmarkSidebarSettings.vue
+++ b/entrypoints/newtab/components/SettingsPage/Settings/BookmarkSidebarSettings.vue
@@ -91,9 +91,15 @@ const sortModeOptions = [
           />
         </el-select>
       </div>
-      <div class="settings__item settings__item--horizontal">
+      <div class="settings__item settings__item--horizontal settings__item--with-note">
         <div class="settings__label">{{ t('bookmark.rightClickToOpen') }}</div>
-        <el-switch v-model="settings.bookmark.rightClickToOpen" />
+        <el-switch
+          v-model="settings.bookmark.rightClickToOpen"
+          :disabled="settings.dock.launchpad.rightClickToOpen"
+        />
+        <p v-if="settings.dock.launchpad.rightClickToOpen" class="settings__item-note">
+          {{ t('bookmark.rightClickDisabledNote') }}
+        </p>
       </div>
     </SettingsSection>
   </div>

--- a/entrypoints/newtab/components/SettingsPage/Settings/DockSettings.vue
+++ b/entrypoints/newtab/components/SettingsPage/Settings/DockSettings.vue
@@ -71,6 +71,16 @@ async function restoreDefaultTopSites() {
           <div class="settings__label">{{ t('common.openInNewTab') }}</div>
           <el-switch v-model="settings.dock.launchpad.openInNewTab" />
         </div>
+        <div class="settings__item settings__item--horizontal settings__item--with-note">
+          <div class="settings__label">{{ t('dock.launchpad.rightClickToOpen') }}</div>
+          <el-switch
+            v-model="settings.dock.launchpad.rightClickToOpen"
+            :disabled="settings.bookmark.rightClickToOpen"
+          />
+          <p v-if="settings.bookmark.rightClickToOpen" class="settings__item-note">
+            {{ t('dock.launchpad.rightClickDisabledNote') }}
+          </p>
+        </div>
       </template>
     </SettingsSection>
 

--- a/locales/en/settings.json
+++ b/locales/en/settings.json
@@ -100,6 +100,7 @@
       "rtl": "Right to left",
       "title": "Open direction"
     },
+    "rightClickDisabledNote": "Right-click to open Launchpad is enabled. Turn it off first.",
     "rightClickToOpen": "Right click on background to open",
     "showBtn": "Show bottom-right button",
     "title": "Bookmarks bar"
@@ -182,6 +183,8 @@
     "actionBtnNote": "When Dock is enabled, the button bar can only be placed at the top (choose left/right in Layout settings)",
     "borderRadius": "Radius",
     "launchpad": {
+      "rightClickDisabledNote": "Right-click to open bookmarks is enabled. Turn it off first.",
+      "rightClickToOpen": "Right click on background to open",
       "show": "Show Launchpad in Dock",
       "title": "Launchpad"
     },

--- a/locales/zh-CN/settings.json
+++ b/locales/zh-CN/settings.json
@@ -100,6 +100,7 @@
       "rtl": "从右到左",
       "title": "打开方向"
     },
+    "rightClickDisabledNote": "已启用右键背景打开启动台，请先将其关闭。",
     "rightClickToOpen": "右键背景打开",
     "showBtn": "显示右下角入口",
     "title": "书签栏"
@@ -182,6 +183,8 @@
     "actionBtnNote": "开启 Dock 后，功能按钮只能放在顶部（可在「布局」中选择左/右）",
     "borderRadius": "圆角",
     "launchpad": {
+      "rightClickDisabledNote": "已启用右键背景打开书签栏，请先将其关闭。",
+      "rightClickToOpen": "右键背景打开",
       "show": "在 Dock 中启用启动台",
       "title": "启动台"
     },

--- a/locales/zh-HK/settings.json
+++ b/locales/zh-HK/settings.json
@@ -100,6 +100,7 @@
       "rtl": "從右到左",
       "title": "打開方向"
     },
+    "rightClickDisabledNote": "已啟用右鍵背景打開啟動台，請先將其關閉。",
     "rightClickToOpen": "右鍵背景打開",
     "showBtn": "顯示右下角按鈕",
     "title": "書籤欄"
@@ -182,6 +183,8 @@
     "actionBtnNote": "開啟 Dock 後，功能按鈕只能放在頂部（可在「佈局」中選擇左/右）",
     "borderRadius": "圓角",
     "launchpad": {
+      "rightClickDisabledNote": "已啟用右鍵背景打開書籤欄，請先將其關閉。",
+      "rightClickToOpen": "右鍵背景打開",
       "show": "在 Dock 中啟用啟動台",
       "title": "啟動台"
     },

--- a/locales/zh-TW/settings.json
+++ b/locales/zh-TW/settings.json
@@ -100,6 +100,7 @@
       "rtl": "從右到左",
       "title": "打開方向"
     },
+    "rightClickDisabledNote": "已啟用右鍵背景打開啟動台，請先將其關閉。",
     "rightClickToOpen": "右鍵背景打開",
     "showBtn": "顯示右下角快捷入口",
     "title": "書籤欄"
@@ -182,6 +183,8 @@
     "actionBtnNote": "開啟 Dock 後，功能按鈕只能放在頂部（可在「佈局」中選擇左/右）",
     "borderRadius": "圓角",
     "launchpad": {
+      "rightClickDisabledNote": "已啟用右鍵背景打開書籤欄，請先將其關閉。",
+      "rightClickToOpen": "右鍵背景打開",
       "show": "在 Dock 中啟用啟動台",
       "title": "啟動台"
     },

--- a/shared/settings/default.ts
+++ b/shared/settings/default.ts
@@ -175,6 +175,7 @@ export const defaultSettings = {
       enabled: false,
       topSites: true,
       openInNewTab: false,
+      rightClickToOpen: false,
     },
   },
 

--- a/shared/settings/migrate/fromVer10.ts
+++ b/shared/settings/migrate/fromVer10.ts
@@ -43,6 +43,10 @@ export function migrateFromVer10To11(old: SettingsSchemaV10): SettingsSchemaV11 
     dock: {
       ...rest.dock,
       borderRadius: defaultSettings.dock.borderRadius,
+      launchpad: {
+        ...rest.dock.launchpad,
+        rightClickToOpen: defaultSettings.dock.launchpad.rightClickToOpen,
+      },
     },
     yiyan: {
       ...rest.yiyan,

--- a/shared/settings/normalize.ts
+++ b/shared/settings/normalize.ts
@@ -149,6 +149,18 @@ export function normalizeCurrentSettings(settings: CURRENT_CONFIG_SCHEMA): CURRE
     normalized.layout.minimalModeOnDoubleClick,
     defaultSettings.layout.minimalModeOnDoubleClick,
   )
+  normalized.dock.launchpad.rightClickToOpen = normalizeBoolean(
+    normalized.dock.launchpad.rightClickToOpen,
+    defaultSettings.dock.launchpad.rightClickToOpen,
+  )
+  normalized.bookmark.rightClickToOpen = normalizeBoolean(
+    normalized.bookmark.rightClickToOpen,
+    defaultSettings.bookmark.rightClickToOpen,
+  )
+  // 两个背景右键动作不能同时生效；旧设置中的书签行为优先保留。
+  if (normalized.bookmark.rightClickToOpen) {
+    normalized.dock.launchpad.rightClickToOpen = false
+  }
 
   const { bing } = normalized.background
   if (!isBingWallpaperResolution(bing.resolution)) {

--- a/shared/settings/types/v11.ts
+++ b/shared/settings/types/v11.ts
@@ -19,6 +19,7 @@ export interface SettingsSchemaV11 extends Omit<
   | 'yiyan'
   | 'layout'
   | 'dock'
+  | 'bookmark'
   | 'perf'
   | 'background'
 > {
@@ -63,8 +64,15 @@ export interface SettingsSchemaV11 extends Omit<
     minimalModeOnDoubleClick: boolean
   }
 
-  dock: SettingsSchemaV10['dock'] & {
+  dock: Omit<SettingsSchemaV10['dock'], 'launchpad'> & {
     borderRadius: number
+    launchpad: SettingsSchemaV10['dock']['launchpad'] & {
+      rightClickToOpen: boolean
+    }
+  }
+
+  bookmark: SettingsSchemaV10['bookmark'] & {
+    rightClickToOpen: boolean
   }
 
   perf: Omit<


### PR DESCRIPTION
### Motivation

- 提供与原有“右键背景打开书签栏”相似的交互方案，允许通过右键在背景上直接打开/关闭 Launchpad。 
- 防止两个右键动作冲突，因此在设置层面让两者互斥并在被禁用时显示提示说明。

### Description

- 在设置类型与默认值中新增 `dock.launchpad.rightClickToOpen` 与 `bookmark.rightClickToOpen` 字段并在 `shared/settings/types/v11.ts` 与 `shared/settings/default.ts` 中补齐相应结构和默认值。 
- 在设置规范化与迁移逻辑 (`shared/settings/normalize.ts` 与 `shared/settings/migrate/fromVer10.ts`) 中加入新字段的校验/默认赋值，并在两个开关同时为启用时以书签行为为优先（将 Launchpad 的右键行为关闭）。
- 在界面层添加对 Launchpad 右键开关的控制：将 Dock 暴露 `toggleLaunchpad`，并在 `entrypoints/newtab/App.vue` 的背景右键处理器中根据优先级触发 Launchpad 或书签侧栏的打开。 
- 在设置页面中更新 `DockSettings.vue` 与 `BookmarkSidebarSettings.vue`，使两个互斥开关在冲突时被禁用并显示小字提示，且补充 `en/zh-CN/zh-HK/zh-TW` 四种语言的提示文案。

### Testing

- `pnpm exec wxt prepare && pnpm type-check` 执行通过，类型检查在先运行 WXT 类型生成后通过；
- `pnpm lint`（包含 `oxlint`/`eslint`/`stylelint`）执行通过；
- `git diff --check` / 变更校验通过；
- `pnpm build` 在不先执行 `wxt prepare` 的情况下可能在本环境中出现与自动生成的导入声明相关的短暂错误，已验证在先运行 `wxt prepare` 后类型检查可通过（建议 CI 在构建前运行 `wxt prepare`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a98cf91325c832a925e547ad8798355)