### PR TITLE
:sparkles: 增加启动台图标大小设置

### DIFF
--- a/entrypoints/newtab/components/QuickLinks/Launchpad.vue
+++ b/entrypoints/newtab/components/QuickLinks/Launchpad.vue
@@ -139,9 +139,8 @@ const COLS = computed(() => {
 })
 const ROWS = computed(() => {
   const isSmall = windowWidth.value <= 500
-  const isMid = windowWidth.value <= 800
   const h = containerHeight.value - (isSmall ? 70 : 88) - 64
-  const rowHeight = isSmall ? 106 : isMid ? 114 : 122
+  const rowHeight = settings.dock.launchpad.iconSize + 50
   return Math.max(1, Math.floor((h + 8) / rowHeight))
 })
 
@@ -592,6 +591,7 @@ onBeforeUnmount(() => {
           <div
             ref="container"
             class="launchpad-wrapper"
+            :style="{ '--launchpad-icon-size': `${settings.dock.launchpad.iconSize}px` }"
             tabindex="-1"
             @click.self="close"
             @contextmenu.prevent.stop
@@ -1255,22 +1255,18 @@ onBeforeUnmount(() => {
     flex-shrink: 0;
     align-items: center;
     justify-content: center;
-    width: 72px;
-    height: 72px;
+    width: var(--launchpad-icon-size);
+    height: var(--launchpad-icon-size);
     margin-bottom: 8px;
     overflow: hidden;
     border-radius: calc(var(--le-radius-base, 20px) * 0.9);
     transition: 0.15s ease;
 
     @media (width <= 800px) {
-      width: 64px;
-      height: 64px;
       border-radius: calc(var(--le-radius-base, 20px) * 0.7);
     }
 
     @media (width <= 500px) {
-      width: 56px;
-      height: 56px;
       border-radius: var(--le-radius-medium, 12px);
     }
 

--- a/entrypoints/newtab/components/SettingsPage/Settings/DockSettings.vue
+++ b/entrypoints/newtab/components/SettingsPage/Settings/DockSettings.vue
@@ -71,6 +71,17 @@ async function restoreDefaultTopSites() {
           <div class="settings__label">{{ t('common.openInNewTab') }}</div>
           <el-switch v-model="settings.dock.launchpad.openInNewTab" />
         </div>
+        <div class="settings__item settings__item--vertical settings-control-wide">
+          <div class="settings__label">{{ t('dock.launchpad.iconSize') }}</div>
+          <el-slider
+            v-model="settings.dock.launchpad.iconSize"
+            :min="40"
+            :max="96"
+            show-input
+            :show-input-controls="false"
+            :show-tooltip="false"
+          />
+        </div>
       </template>
     </SettingsSection>
 

--- a/locales/en/settings.json
+++ b/locales/en/settings.json
@@ -182,6 +182,7 @@
     "actionBtnNote": "When Dock is enabled, the button bar can only be placed at the top (choose left/right in Layout settings)",
     "borderRadius": "Radius",
     "launchpad": {
+      "iconSize": "Icon size",
       "show": "Show Launchpad in Dock",
       "title": "Launchpad"
     },

--- a/locales/zh-CN/settings.json
+++ b/locales/zh-CN/settings.json
@@ -182,6 +182,7 @@
     "actionBtnNote": "开启 Dock 后，功能按钮只能放在顶部（可在「布局」中选择左/右）",
     "borderRadius": "圆角",
     "launchpad": {
+      "iconSize": "图标大小",
       "show": "在 Dock 中启用启动台",
       "title": "启动台"
     },

--- a/locales/zh-HK/settings.json
+++ b/locales/zh-HK/settings.json
@@ -182,6 +182,7 @@
     "actionBtnNote": "開啟 Dock 後，功能按鈕只能放在頂部（可在「佈局」中選擇左/右）",
     "borderRadius": "圓角",
     "launchpad": {
+      "iconSize": "圖示大小",
       "show": "在 Dock 中啟用啟動台",
       "title": "啟動台"
     },

--- a/locales/zh-TW/settings.json
+++ b/locales/zh-TW/settings.json
@@ -182,6 +182,7 @@
     "actionBtnNote": "開啟 Dock 後，功能按鈕只能放在頂部（可在「佈局」中選擇左/右）",
     "borderRadius": "圓角",
     "launchpad": {
+      "iconSize": "圖示大小",
       "show": "在 Dock 中啟用啟動台",
       "title": "啟動台"
     },

--- a/shared/settings/default.ts
+++ b/shared/settings/default.ts
@@ -175,6 +175,7 @@ export const defaultSettings = {
       enabled: false,
       topSites: true,
       openInNewTab: false,
+      iconSize: 72,
     },
   },
 

--- a/shared/settings/migrate/fromVer10.ts
+++ b/shared/settings/migrate/fromVer10.ts
@@ -43,6 +43,10 @@ export function migrateFromVer10To11(old: SettingsSchemaV10): SettingsSchemaV11 
     dock: {
       ...rest.dock,
       borderRadius: defaultSettings.dock.borderRadius,
+      launchpad: {
+        ...rest.dock.launchpad,
+        iconSize: defaultSettings.dock.launchpad.iconSize,
+      },
     },
     yiyan: {
       ...rest.yiyan,

--- a/shared/settings/normalize.ts
+++ b/shared/settings/normalize.ts
@@ -26,6 +26,8 @@ const MIN_GLOBAL_BORDER_RADIUS = 0
 const MAX_GLOBAL_BORDER_RADIUS = 40
 const MIN_DOCK_BORDER_RADIUS = 0
 const MAX_DOCK_BORDER_RADIUS = 40
+const MIN_LAUNCHPAD_ICON_SIZE = 40
+const MAX_LAUNCHPAD_ICON_SIZE = 96
 type PerfTransparencyKey =
   | 'bookmark'
   | 'dialog'
@@ -62,7 +64,11 @@ type MutableCurrentSettings = CURRENT_CONFIG_SCHEMA & {
   layout?: Omit<CURRENT_CONFIG_SCHEMA['layout'], 'minimalModeOnDoubleClick'> & {
     minimalModeOnDoubleClick?: unknown
   }
-  dock?: CURRENT_CONFIG_SCHEMA['dock']
+  dock?: Omit<CURRENT_CONFIG_SCHEMA['dock'], 'launchpad'> & {
+    launchpad?: Omit<CURRENT_CONFIG_SCHEMA['dock']['launchpad'], 'iconSize'> & {
+      iconSize?: unknown
+    }
+  }
   perf?: CURRENT_CONFIG_SCHEMA['perf']
 }
 
@@ -135,6 +141,7 @@ export function normalizeCurrentSettings(settings: CURRENT_CONFIG_SCHEMA): CURRE
   normalized.yiyan ??= structuredClone(defaultSettings.yiyan)
   normalized.layout ??= structuredClone(defaultSettings.layout)
   normalized.dock ??= structuredClone(defaultSettings.dock)
+  normalized.dock.launchpad ??= structuredClone(defaultSettings.dock.launchpad)
   normalized.perf ??= structuredClone(defaultSettings.perf)
 
   normalized.theme.keepClockVisibleOnIdle = normalizeBoolean(
@@ -227,6 +234,12 @@ export function normalizeCurrentSettings(settings: CURRENT_CONFIG_SCHEMA): CURRE
     defaultSettings.dock.borderRadius,
     MIN_DOCK_BORDER_RADIUS,
     MAX_DOCK_BORDER_RADIUS,
+  )
+  normalized.dock.launchpad.iconSize = clampInteger(
+    normalized.dock.launchpad.iconSize,
+    defaultSettings.dock.launchpad.iconSize,
+    MIN_LAUNCHPAD_ICON_SIZE,
+    MAX_LAUNCHPAD_ICON_SIZE,
   )
 
   normalizePerfSurface(normalized.perf, 'bookmark')

--- a/shared/settings/types/v11.ts
+++ b/shared/settings/types/v11.ts
@@ -63,8 +63,11 @@ export interface SettingsSchemaV11 extends Omit<
     minimalModeOnDoubleClick: boolean
   }
 
-  dock: SettingsSchemaV10['dock'] & {
+  dock: Omit<SettingsSchemaV10['dock'], 'launchpad'> & {
     borderRadius: number
+    launchpad: SettingsSchemaV10['dock']['launchpad'] & {
+      iconSize: number
+    }
   }
 
   perf: Omit<


### PR DESCRIPTION
### Motivation

- Provide users the ability to adjust Launchpad icon size because the default icons can feel too large in some layouts. 
- Ensure the new setting is persisted, validated and safely migrated from older config versions. 

### Description

- Add `dock.launchpad.iconSize` to the settings schema (`shared/settings/types/v11.ts`) and set a default value of `72` in `shared/settings/default.ts`. 
- Expose a settings control: add an `el-slider` (40–96) bound to `settings.dock.launchpad.iconSize` in `entrypoints/newtab/components/SettingsPage/Settings/DockSettings.vue`. 
- Make Launchpad layout responsive to the chosen size by binding `--launchpad-icon-size` on the Launchpad wrapper and using it in the component styles, and recompute rows based on `settings.dock.launchpad.iconSize` in `entrypoints/newtab/components/QuickLinks/Launchpad.vue`. 
- Add normalization and migration: clamp and normalize imported/legacy values in `shared/settings/normalize.ts` and include `launchpad.iconSize` in migration from v10 in `shared/settings/migrate/fromVer10.ts`. 
- Add localized labels for the new setting in `locales/*/settings.json` (en / zh-CN / zh-HK / zh-TW). 

### Testing

- Ran `pnpm lint:check`, which completed successfully. 
- Ran `git diff --check`, which returned clean. 
- Ran `pnpm type-check`, which exited with errors unrelated to this change (the repository requires generated automatic imports / ambient declarations to be present before a full type check), and the migration/normalize additions address the direct typing mismatch for the new `launchpad.iconSize` field but do not resolve the repository-wide ambient import generation requirement. 
- Confirmed changes were committed (commit `17541c1`), but no remote PR was created from this environment due to missing Git remotes and tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a98ddb19694832a98a8d2e66914216b)