### PR TITLE
✨ 在导航项右键菜单增加无痕窗口打开功能

### DIFF
--- a/entrypoints/newtab/components/Bookmark/components/BookmarkItem.vue
+++ b/entrypoints/newtab/components/Bookmark/components/BookmarkItem.vue
@@ -5,6 +5,7 @@ import { useDraggable, useDroppable } from '@dnd-kit/vue'
 import type { DropdownInstance } from 'element-plus'
 import { useTranslation } from 'i18next-vue'
 import Dismiss12Regular from '~icons/fluent/dismiss-12-regular'
+import Incognito16Regular from '~icons/fluent/incognito-16-regular'
 import Pin12Regular from '~icons/fluent/pin-12-regular'
 import EditOutlined from '~icons/ic/outline-edit'
 import ContentCopyRound from '~icons/ic/round-content-copy'
@@ -201,6 +202,11 @@ function openInNewWindow() {
   browser.windows.create({ url: props.node.url })
 }
 
+function openInIncognitoWindow() {
+  if (!props.node.url || !isSafeUrl(props.node.url)) return
+  browser.windows.create({ incognito: true, url: props.node.url })
+}
+
 function copyLink() {
   if (!props.node.url) return
   navigator.clipboard.writeText(props.node.url)
@@ -379,6 +385,9 @@ function collapseOther(_e: Event | undefined, all: boolean = false) {
             </el-dropdown-item>
             <el-dropdown-item :icon="OpenInNewRound" @click="openInNewWindow">
               <span>{{ t('settings:common.openInNewWindow') }}</span>
+            </el-dropdown-item>
+            <el-dropdown-item :icon="Incognito16Regular" @click="openInIncognitoWindow">
+              <span>{{ t('settings:common.openInIncognitoWindow') }}</span>
             </el-dropdown-item>
             <el-dropdown-item :icon="ContentCopyRound" divided @click="copyLink">
               <span>{{ t('settings:common.copyLink') }}</span>

--- a/entrypoints/newtab/components/QuickLinks/components/QuickLinkContextMenu.vue
+++ b/entrypoints/newtab/components/QuickLinks/components/QuickLinkContextMenu.vue
@@ -5,6 +5,7 @@ import ChevronLeft20Filled from '~icons/fluent/chevron-left-20-filled'
 import ChevronRight20Filled from '~icons/fluent/chevron-right-20-filled'
 import Edit16Regular from '~icons/fluent/edit-16-regular'
 import FolderArrowRight16Regular from '~icons/fluent/folder-arrow-right-16-regular'
+import Incognito16Regular from '~icons/fluent/incognito-16-regular'
 import Pin12Regular from '~icons/fluent/pin-12-regular'
 import PinOff16Regular from '~icons/fluent/pin-off-16-regular'
 import Star12Regular from '~icons/fluent/star-12-regular'
@@ -57,6 +58,7 @@ const {
   setCtxContext,
   ctxOpenInNewTab,
   ctxOpenInNewWindow,
+  ctxOpenInIncognitoWindow,
   ctxCopyLink,
   ctxCreateBookmark,
   ctxUnpin,
@@ -125,6 +127,9 @@ defineExpose({ open, close })
         </el-dropdown-item>
         <el-dropdown-item :icon="OpenInNewRound" @click="ctxOpenInNewWindow">
           <span>{{ t('settings:common.openInNewWindow') }}</span>
+        </el-dropdown-item>
+        <el-dropdown-item :icon="Incognito16Regular" @click="ctxOpenInIncognitoWindow">
+          <span>{{ t('settings:common.openInIncognitoWindow') }}</span>
         </el-dropdown-item>
         <el-dropdown-item :icon="ContentCopyRound" @click="ctxCopyLink">
           <span>{{ t('settings:common.copyLink') }}</span>

--- a/entrypoints/newtab/components/QuickLinks/composables/useQuickLinkContextMenu.ts
+++ b/entrypoints/newtab/components/QuickLinks/composables/useQuickLinkContextMenu.ts
@@ -57,6 +57,11 @@ export function useQuickLinkContextMenu(options: {
       browser.windows.create({ url: ctxItem.value.url })
   }
 
+  const ctxOpenInIncognitoWindow = (): void => {
+    if (ctxItem.value && isSafeUrl(ctxItem.value.url))
+      browser.windows.create({ incognito: true, url: ctxItem.value.url })
+  }
+
   const ctxCopyLink = (): void => {
     if (ctxItem.value) navigator.clipboard.writeText(ctxItem.value.url)
   }
@@ -125,6 +130,7 @@ export function useQuickLinkContextMenu(options: {
     setCtxContext,
     ctxOpenInNewTab,
     ctxOpenInNewWindow,
+    ctxOpenInIncognitoWindow,
     ctxCopyLink,
     ctxCreateBookmark,
     ctxUnpin,

--- a/locales/en/settings.json
+++ b/locales/en/settings.json
@@ -166,6 +166,7 @@
     "hour": "Hour",
     "openInNewTab": "Open in New Tab",
     "openInNewWindow": "Open in New Window",
+    "openInIncognitoWindow": "Open in Incognito Window",
     "sections": {
       "animation": "Animations",
       "appearance": "Appearance",

--- a/locales/tr-TR/settings.json
+++ b/locales/tr-TR/settings.json
@@ -166,6 +166,7 @@
     "hour": "Saat",
     "openInNewTab": "Yeni Sekmede Aç",
     "openInNewWindow": "Yeni Pencerede Aç",
+    "openInIncognitoWindow": "Gizli Pencerede Aç",
     "sections": {
       "animation": "Animasyonlar",
       "appearance": "Görünüm",

--- a/locales/zh-CN/settings.json
+++ b/locales/zh-CN/settings.json
@@ -166,6 +166,7 @@
     "hour": "小时",
     "openInNewTab": "在新标签页中打开",
     "openInNewWindow": "在新窗口中打开",
+    "openInIncognitoWindow": "在无痕窗口中打开",
     "sections": {
       "animation": "动画",
       "appearance": "外观",

--- a/locales/zh-HK/settings.json
+++ b/locales/zh-HK/settings.json
@@ -166,6 +166,7 @@
     "hour": "個鈡",
     "openInNewTab": "在新分頁中開啟",
     "openInNewWindow": "在新視窗中開啟",
+    "openInIncognitoWindow": "在無痕視窗中開啟",
     "sections": {
       "animation": "動畫",
       "appearance": "外觀",

--- a/locales/zh-TW/settings.json
+++ b/locales/zh-TW/settings.json
@@ -166,6 +166,7 @@
     "hour": "小時",
     "openInNewTab": "在新分頁中開啟",
     "openInNewWindow": "在新視窗中開啟",
+    "openInIncognitoWindow": "在無痕視窗中開啟",
     "sections": {
       "animation": "動畫",
       "appearance": "外觀",


### PR DESCRIPTION
### Motivation

- 为 Issue #115 提供无痕（Incognito/InPrivate）快速打开入口，方便用户在快速导航、Dock、Launchpad 与书签项的右键菜单直接在无痕窗口打开链接。

### Description

- 在 Quick Links 共用的右键菜单中新增“在无痕窗口中打开”菜单项并引入对应图标（`Incognito16Regular`），调用 `ctxOpenInIncognitoWindow`；实现文件为 `entrypoints/newtab/components/QuickLinks/components/QuickLinkContextMenu.vue` 与其组合式逻辑 `useQuickLinkContextMenu.ts`。
- 在书签项右键菜单中同样增加 `openInIncognitoWindow` 并在 `entrypoints/newtab/components/Bookmark/components/BookmarkItem.vue` 中实现，使用 `browser.windows.create({ incognito: true, url })` 在校验 URL 安全后打开。
- 为英语、土耳其语、简体中文、繁体（香港/台湾）补充 i18n 文案键 `settings:common.openInIncognitoWindow`（`locales/{en,tr-TR,zh-CN,zh-HK,zh-TW}/settings.json`）。

### Testing

- 运行 `pnpm lint:check`，检查通过。
- 运行 `pnpm exec wxt build`，扩展构建成功完成且产物生成成功。
- 运行 `git diff --check`，无差异检查问题。
- 运行 `pnpm type-check` 出现项目范围的 TypeScript auto-import / Pinia 类型错误（由缺失的自动生成声明文件影响），因此本次变更的类型检查在当前环境下被影响，但构建产物已验证功能实现。

------
Refs #115 

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa0c8b96798832a9a96cad2cf6d385d)