### PR TITLE
✨ 为搜索框增加网址识别与跳转建议

### DIFF
--- a/entrypoints/newtab/components/SearchBox/components/SearchSuggestionArea.vue
+++ b/entrypoints/newtab/components/SearchBox/components/SearchSuggestionArea.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { useTranslation } from 'i18next-vue'
+import Globe from '~icons/fa6-solid/earth-americas'
+import Search from '~icons/fa6-solid/magnifying-glass'
 import TrashAlt from '~icons/fa6-solid/trash-can'
 
 import { BgType } from '@/shared/enums'
@@ -9,6 +11,7 @@ import { useFocusState } from '@newtab/composables/useFocus'
 import usePerfClasses from '@newtab/composables/usePerfClasses'
 import { useSearchHistoryCache } from '@newtab/composables/useSearchHistoryCache'
 import { searchSuggestAPIs, searchSuggestCache } from '@newtab/shared/search'
+import { parseNavigableUrl } from '@newtab/shared/search/url'
 
 import SuggestListItem from './SuggestListItem.vue'
 
@@ -40,9 +43,26 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   doSearchWithText: [text: string]
+  navigateToUrl: [url: string]
   activeOptionChange: [id: string | undefined]
   expandedChange: [expanded: boolean]
 }>()
+
+type DisplayedSuggestion = { action: 'navigate' | 'search' | 'suggest'; text: string }
+
+const navigableUrl = computed(() => parseNavigableUrl(props.searchText))
+const displayedSuggestions = computed<DisplayedSuggestion[]>(() => {
+  const suggestions = searchSuggestions.value.slice(0, navigableUrl.value ? 8 : 10).map((text) => ({
+    action: 'suggest' as const,
+    text,
+  }))
+  if (!navigableUrl.value) return suggestions
+  return [
+    { action: 'navigate', text: navigableUrl.value.text },
+    { action: 'search', text: navigableUrl.value.text },
+    ...suggestions,
+  ]
+})
 
 const perf = usePerfClasses(() => ({
   transparent: settings.perf.searchBar.transparent,
@@ -54,13 +74,13 @@ const suggestionAreaPerfClass = computed(() => [
   {
     'search-suggestion-area--shadow': settings.search.style.shadow,
     'search-suggestion-area--dark':
-      settings.background.bgType === BgType.None && searchSuggestions.value.length > 0,
+      settings.background.bgType === BgType.None && displayedSuggestions.value.length > 0,
   },
   perf('search-suggestion-area').value,
 ])
 
 const areaHeight = computed(() => {
-  const length = searchSuggestions.value.length
+  const length = displayedSuggestions.value.length
   if (length === 0) {
     return '0'
   }
@@ -70,11 +90,6 @@ const areaHeight = computed(() => {
   return isShowSearchHistories.value ? `${(length + 1) * 33}px` : `${length * 33}px`
 })
 
-const displayedSuggestions = computed(() =>
-  searchSuggestions.value.length > 10
-    ? searchSuggestions.value.slice(0, 10)
-    : searchSuggestions.value,
-)
 const activeOptionId = computed(() => {
   const index = currentActiveSuggest.value
   if (index === null || index >= displayedSuggestions.value.length) {
@@ -265,13 +280,23 @@ function clearActiveSuggest() {
 }
 
 function activateSuggest(index: number): string | null {
-  const nextText = displayedSuggestions.value[index]
-  if (!nextText) {
+  const nextItem = displayedSuggestions.value[index]
+  if (!nextItem) {
     return null
   }
 
   currentActiveSuggest.value = index
-  return nextText
+  return nextItem.text
+}
+
+function submitActiveSuggest() {
+  const index = currentActiveSuggest.value
+  if (index === null) return false
+  const item = displayedSuggestions.value[index]
+  if (!item) return false
+  if (item.action === 'navigate' && navigableUrl.value) emit('navigateToUrl', navigableUrl.value.url)
+  else emit('doSearchWithText', item.text)
+  return true
 }
 
 function hideSearchHistories() {
@@ -339,6 +364,7 @@ defineExpose({
   showSearchHistories,
   handleInput,
   navigateActiveSuggest,
+  submitActiveSuggest,
 })
 </script>
 
@@ -359,9 +385,21 @@ defineExpose({
       v-for="(item, index) in displayedSuggestions"
       :key="index"
       :id="`${listId}-option-${index}`"
-      :text="item"
+      :text="
+        item.action === 'navigate'
+          ? t('newtab:search.navigateTo', { url: item.text })
+          : item.action === 'search'
+            ? t('newtab:search.searchFor', { text: item.text })
+            : item.text
+      "
+      :icon="item.action === 'navigate' ? Globe : item.action === 'search' ? Search : undefined"
+      :muted="item.action !== 'suggest'"
       :active="currentActiveSuggest === index"
-      @click="emit('doSearchWithText', item)"
+      @click="
+        item.action === 'navigate' && navigableUrl
+          ? emit('navigateToUrl', navigableUrl.url)
+          : emit('doSearchWithText', item.text)
+      "
       @hover="currentActiveSuggest = index"
       @leave="currentActiveSuggest = currentActiveSuggest === index ? null : currentActiveSuggest"
     />
@@ -432,6 +470,21 @@ defineExpose({
     &--active {
       padding-left: 40px;
       background-color: var(--le-bg-color-overlay-search-subtle);
+    }
+
+    &--muted {
+      color: var(--el-text-color-secondary);
+    }
+
+    &-icon {
+      flex: none;
+      margin-right: 8px;
+    }
+
+    &-text {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
 

--- a/entrypoints/newtab/components/SearchBox/components/SuggestListItem.vue
+++ b/entrypoints/newtab/components/SearchBox/components/SuggestListItem.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
+import type { Component } from 'vue'
+
 const props = defineProps<{
   id?: string
   text: string
   active: boolean
+  icon?: Component
+  muted?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -16,13 +20,17 @@ const emit = defineEmits<{
   <div
     :id="id"
     class="search-suggestion-area__item noselect"
-    :class="{ 'search-suggestion-area__item--active': active }"
+    :class="{
+      'search-suggestion-area__item--active': active,
+      'search-suggestion-area__item--muted': muted,
+    }"
     role="option"
     :aria-selected="active"
     @click="emit('click')"
     @mouseover="emit('hover')"
     @mouseout="emit('leave')"
   >
-    {{ props.text }}
+    <el-icon v-if="icon" class="search-suggestion-area__item-icon"><component :is="icon" /></el-icon>
+    <span class="search-suggestion-area__item-text">{{ props.text }}</span>
   </div>
 </template>

--- a/entrypoints/newtab/components/SearchBox/index.vue
+++ b/entrypoints/newtab/components/SearchBox/index.vue
@@ -24,6 +24,7 @@ import {
   getSearchEngineUrl,
   searchEngines,
 } from '@newtab/shared/search'
+import { parseNavigableUrl } from '@newtab/shared/search/url'
 
 import SearchEngineMenu from './components/SearchEngineMenu.vue'
 import SearchSuggestionArea from './components/SearchSuggestionArea.vue'
@@ -37,6 +38,7 @@ type SearchSuggestionAreaController = {
     currentText: string,
     originText: string | null,
   ) => { searchText: string; originSearchText: string } | null
+  submitActiveSuggest: () => boolean
 }
 
 const searchBox = useTemplateRef('searchBox')
@@ -237,7 +239,19 @@ const doSearchWithText = async (text: string, newtab: boolean = false) => {
   suggestionArea.value?.clearSearchSuggestions()
 }
 
+function navigateToUrl(url: string) {
+  window.open(url, settings.search.openInNewTab ? '_blank' : '_self', 'noopener noreferrer')
+  suggestionArea.value?.clearSearchSuggestions()
+}
+
 function doSearch() {
+  if (suggestionArea.value?.submitActiveSuggest()) return
+  const navigableUrl = parseNavigableUrl(searchText.value)
+  if (navigableUrl) {
+    navigateToUrl(navigableUrl.url)
+    searchText.value = ''
+    return
+  }
   doSearchWithText(searchText.value)
   searchText.value = ''
 }
@@ -306,6 +320,7 @@ onMounted(() => {
       :search-text="searchText"
       :search-form-width="searchFormWidth"
       @do-search-with-text="doSearchWithText"
+      @navigate-to-url="navigateToUrl"
       @active-option-change="activeSuggestionOptionId = $event"
       @expanded-change="searchSuggestionsExpanded = $event"
     />

--- a/entrypoints/newtab/shared/search/url.ts
+++ b/entrypoints/newtab/shared/search/url.ts
@@ -1,0 +1,60 @@
+export type NavigableUrl = {
+  text: string
+  url: string
+}
+
+const domainLabelPattern = /^[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?$/i
+
+function isStrictIpv4(hostname: string) {
+  const segments = hostname.split('.')
+  return (
+    segments.length === 4 &&
+    segments.every(
+      (segment) => /^\d+$/.test(segment) && Number(segment) >= 0 && Number(segment) <= 255,
+    )
+  )
+}
+
+function isDomain(hostname: string) {
+  return (
+    hostname.length <= 253 &&
+    hostname.includes('.') &&
+    hostname.split('.').every((label) => domainLabelPattern.test(label))
+  )
+}
+
+function rawHostname(input: string) {
+  const authority = input.replace(/^https?:\/\//i, '').split(/[/?#]/, 1)[0] ?? ''
+  const withoutCredentials = authority.slice(authority.lastIndexOf('@') + 1)
+  if (withoutCredentials.startsWith('[')) {
+    return withoutCredentials.slice(0, withoutCredentials.indexOf(']') + 1)
+  }
+  return withoutCredentials.split(':', 1)[0] ?? ''
+}
+
+/** 将明确形似 HTTP(S) 地址的输入规范化，避免把普通搜索词误判为网址。 */
+export function parseNavigableUrl(input: string): NavigableUrl | null {
+  const text = input.trim()
+  if (!text || /\s/.test(text)) return null
+
+  const candidate = /^https?:\/\//i.test(text) ? text : `https://${text}`
+  let parsed: URL
+  try {
+    parsed = new URL(candidate)
+  } catch {
+    return null
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol) || !parsed.hostname) return null
+
+  const hostname = parsed.hostname.toLowerCase()
+  const inputHostname = rawHostname(candidate).toLowerCase()
+  const isIpv6 = hostname.startsWith('[') && hostname.endsWith(']')
+  const isLocal = hostname === 'localhost' || hostname.endsWith('.local')
+  const looksLikeIpv4 = /^\d+(?:\.\d+)*$/.test(inputHostname)
+  const isIpv4 = looksLikeIpv4 && isStrictIpv4(inputHostname)
+
+  if (looksLikeIpv4 && !isIpv4) return null
+  if (!isLocal && !isIpv6 && !isIpv4 && !isDomain(hostname)) return null
+  return { text, url: parsed.href }
+}

--- a/locales/en/newtab.json
+++ b/locales/en/newtab.json
@@ -146,7 +146,9 @@
     },
     "placeholder": "Search",
     "purgeSearchHistory": "Clear Search History",
-    "searchEngineNotFound": "Search engine not found"
+    "searchEngineNotFound": "Search engine not found",
+    "navigateTo": "Go to {{url}}",
+    "searchFor": "Search {{text}}"
   },
   "sponsor": "This extension was created by me in my spare time to solve my own needs, and I'm thrilled it helps you too! If you enjoy it, please consider giving it a ⭐ on GitHub—it means a lot to me. Feel free to share your ideas or feedback at: redlnn@outlook.com. Thank you!",
   "time": {

--- a/locales/tr-TR/newtab.json
+++ b/locales/tr-TR/newtab.json
@@ -146,7 +146,9 @@
     },
     "placeholder": "Ara",
     "purgeSearchHistory": "Arama Geçmişini Temizle",
-    "searchEngineNotFound": "Arama motoru bulunamadı"
+    "searchEngineNotFound": "Arama motoru bulunamadı",
+    "navigateTo": "{{url}} adresine git",
+    "searchFor": "{{text}} ara"
   },
   "sponsor": "Bu uzantı, kendi ihtiyaçlarımı çözmek için boş zamanlarımda tarafımdan oluşturuldu ve size de yardımcı olmasına çok sevindim! Beğendiyseniz, lütfen GitHub'da ⭐ vermeyi düşünün—bu benim için çok değerli. Fikirlerinizi veya geri bildirimlerinizi şu adrese göndermekten çekinmeyin: redlnn@outlook.com. Teşekkür ederim!",
   "time": {

--- a/locales/zh-CN/newtab.json
+++ b/locales/zh-CN/newtab.json
@@ -146,7 +146,9 @@
     },
     "placeholder": "搜索",
     "purgeSearchHistory": "清除搜索历史",
-    "searchEngineNotFound": "未找到搜索引擎"
+    "searchEngineNotFound": "未找到搜索引擎",
+    "navigateTo": "跳转到{{url}}",
+    "searchFor": "搜索{{text}}"
   },
   "sponsor": "这个扩展是我利用业余时间开发的小工具，很开心能帮助到你！如果你喜欢它，不妨给个 Star ⭐ 来支持一下，这对我意义重大。如果有任何想法或建议，也欢迎通过邮箱联系我：redlnn@outlook.com。谢谢你的信任！",
   "time": {

--- a/locales/zh-HK/newtab.json
+++ b/locales/zh-HK/newtab.json
@@ -146,7 +146,9 @@
     },
     "placeholder": "搜尋",
     "purgeSearchHistory": "清除搜尋歷史",
-    "searchEngineNotFound": "找不到搜尋引擎"
+    "searchEngineNotFound": "找不到搜尋引擎",
+    "navigateTo": "前往{{url}}",
+    "searchFor": "搜尋{{text}}"
   },
   "sponsor": "呢個擴充功能是我利用業餘時間開發的小工具，好開心能幫到你！如果你鍾意佢嘅話，唔妨俾個 Star ⭐ 來支持一下，咁對我嚟講意義重大。如果有任何想法或建議，都歡迎透過郵箱聯繫我：redlnn@outlook.com。多謝你嘅信任！",
   "time": {

--- a/locales/zh-TW/newtab.json
+++ b/locales/zh-TW/newtab.json
@@ -146,7 +146,9 @@
     },
     "placeholder": "搜尋",
     "purgeSearchHistory": "清除搜尋歷史",
-    "searchEngineNotFound": "找不到搜尋引擎"
+    "searchEngineNotFound": "找不到搜尋引擎",
+    "navigateTo": "前往{{url}}",
+    "searchFor": "搜尋{{text}}"
   },
   "sponsor": "這個擴充功能是我利用業餘時間開發的小工具，很高興能幫助到你！如果你喜歡它，不妨給個 Star ⭐ 來支持一下，這對我意義重大。如果有任何想法或建議，也歡迎透過郵箱聯繫我：redlnn@outlook.com。謝謝你的信任！",
   "time": {


### PR DESCRIPTION
### Motivation

- 提供更便捷的地址栏交互，当用户输入可导航的网址时优先展示“跳转到”和“搜索”操作以提升体验。 

### Description

- 新增严格的 URL 识别与规范化模块 `entrypoints/newtab/shared/search/url.ts`，支持自动补全 `https://`、localhost / `.local`、IPv4/IPv6、国际化域名与合法域名判断。 
- 在搜索建议区域顶部插入两条优先候选：灰色“地球图标 跳转到 + url”与灰色“搜索图标 搜索 + 文本”，并把原有建议项限制与展示逻辑调整为合并后的 `displayedSuggestions` 列表；相关实现位于 `SearchSuggestionArea.vue`。 
- 扩展建议项组件 `SuggestListItem.vue` 以支持图标、次要（muted）样式与文本溢出处理，并在 `SearchBox/index.vue` 中处理回车优先跳转与从建议触发的跳转事件。 
- 同步更新多语言文案（en / zh-CN / zh-HK / zh-TW / tr-TR），新增 `navigateTo` 与 `searchFor` 文案项。 

### Testing

- ✅ 运行 `pnpm lint:check`，通过（有仓库既有的 1 条未使用变量 warning）。
- ✅ 独立类型编译并用脚本验证 `parseNavigableUrl` 对一组接受/拒绝用例，全部通过。 
- ✅ 使用 WXT 启动开发构建，成功生成 Chrome MV3 开发产物（构建通过）；但本地环境缺少 Chrome 可执行导致无法在真实浏览器进程中完成扩展加载运行。 
- ⚠️ 运行 `pnpm type-check` 导致仓库中大量既有全局 Element Plus 辅助类型缺失错误（例如 `ElMessage` / `ElNotification`），这些为仓库范围的类型声明问题，新增代码未引入独立类型错误。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa58f12ad50832a9afcc7808e107119)